### PR TITLE
Remover listaners quando for abrir todas as abas e incluir eles novamente depois

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -33,9 +33,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     // Add event listeners for tab creation and removal
-    chrome.tabs.onCreated.addListener(updateOpenTabs);
-    chrome.tabs.onRemoved.addListener(updateOpenTabs);    
+    addListanersTab();
 });
+
+function addListanersTab() {
+    chrome.tabs.onCreated.addListener(updateOpenTabs);
+    chrome.tabs.onRemoved.addListener(updateOpenTabs);
+}
+
+function removeListaenersTab() {
+    chrome.tabs.onCreated.removeListener(updateOpenTabs);
+    chrome.tabs.onRemoved.removeListener(updateOpenTabs);
+}
 
 // Setup search functionality
 function setupSearch() {
@@ -325,9 +334,14 @@ function setupListActions(listContainer, listName) {
 
 // Função para abrir todas as URLs de uma lista
 function openAllUrls(listName) {
+    removeListaenersTab();
+
     lists[listName].forEach(item => {
         chrome.tabs.create({ url: item.url, active: false });
     });
+
+    updateOpenTabs();
+    addListanersTab();
 }
 
 // Configurar listeners para criação e edição de listas


### PR DESCRIPTION
Quando é clicado para abrir todas as abas de uma vez ele da uma bugada
![image](https://github.com/user-attachments/assets/e3bd31e8-6062-4226-b3d2-8efb2165c503)

Essa atualização faz com que antes de abrir todas as abas o listaner das abas abertas seja removido a incluído novamente no final para evitar essas duplicações